### PR TITLE
Increase client max body size

### DIFF
--- a/resources/conf/nginx.conf
+++ b/resources/conf/nginx.conf
@@ -6,7 +6,15 @@ upstream phpfcgi {
     # server unix:/var/run/php5-fpm.sock; #for PHP-FPM running on UNIX socket
 }
 
+# This affects the maximum uploaded file size.
+client_max_body_size 50M;
+
 server {
+    # Allow per-project configuration. As far as I know it's not possible to
+    # conditionally include a single file, so I'm abusing globbing to get the
+    # same result.
+    include /var/platform/[n]ginx.conf;
+
     listen 80 default_server;
     listen [::]:80 default_server ipv6only=on;
     listen 443 ssl;


### PR DESCRIPTION
Also, if nginx.conf exists in the project root, read it in at the _server_ context level.

See tes/cms-builder#29